### PR TITLE
Increase hover time required to expand globalnavbar

### DIFF
--- a/resource/inject.js
+++ b/resource/inject.js
@@ -119,7 +119,7 @@ DOMReady.add(function(){
 						timer = null;
 						cont.className = cont.className.replace('navbar-hidden', '');
 						
-					}, 400);					
+					}, 1000);					
 				}
 				
 			}


### PR DESCRIPTION
I [experimented with different hover times](http://jsfiddle.net/burke/8uatX/embedded/result/) and 1000 ms (at least 800 ms) feels better than 400 ms.  When on the OpenMRS website with a 400 ms threshold, I am still finding that the globalnavbar often expands unintentionally, especially as Confluence has moved more functionality into their header.
