### PR TITLE
Fix admin route rendering

### DIFF
--- a/lib/global-nav.js
+++ b/lib/global-nav.js
@@ -163,7 +163,7 @@ subApp.get('/globalnav', function(req, res, next) {
   });
 });
 
-subApp.get('/admin/globalnav', mid.restrictTo('dashboard-administrators'), admin.useSidebar, function(req, res, next) {
+app.get('/admin/globalnav', mid.restrictTo('dashboard-administrators'), admin.useSidebar, function(req, res, next) {
   db.getAll('GlobalNavLinks', function(err, links) { // get links
     if (err) return next(err);
     db.getAll('GlobalNavConf', function(err, prefs) { // get preferences
@@ -178,7 +178,7 @@ subApp.get('/admin/globalnav', mid.restrictTo('dashboard-administrators'), admin
   });
 });
 
-subApp.post('/admin/globalnav/links', mid.restrictTo('dashboard-administrators'), mid.parseParamTable, function(req, res, next) {
+app.post('/admin/globalnav/links', mid.restrictTo('dashboard-administrators'), mid.parseParamTable, function(req, res, next) {
   var params = res.local('params');
 
   // push to DB
@@ -210,7 +210,7 @@ subApp.post('/admin/globalnav/links', mid.restrictTo('dashboard-administrators')
 
 });
 
-subApp.post('/admin/globalnav/prefs', mid.restrictTo('dashboard-administrators'), function(req, res, next) {
+app.post('/admin/globalnav/prefs', mid.restrictTo('dashboard-administrators'), function(req, res, next) {
 
   var chain = [],
     dbFinished = 0,


### PR DESCRIPTION
I noticed @plypy has switched admin routes (like /admin/globalnav) to be served by the sub-app, not the core express app configured to render UI.

The trouble with doing it this way is that admin pages don't render the layout properly. And currently, trying to render /admin/globalnav throws an error since the view template expects the `style()` function to be there.

This PR switches admin routes (but _not_ user-facing routes like /globalnav) to be served by the core express app.

@plypy, does this look alright to you?
